### PR TITLE
mixer: explicit casts from void * to other pointer type

### DIFF
--- a/src/asoundlib-head.h
+++ b/src/asoundlib-head.h
@@ -29,7 +29,7 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <endian.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <errno.h>
 #include <stdarg.h>
 

--- a/src/control.c
+++ b/src/control.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include "control.h"
 #include "local.h"
 #if SALSA_SUPPORT_FLOAT

--- a/src/ctl_macros.h
+++ b/src/ctl_macros.h
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 struct _snd_ctl {
 	char *name;

--- a/src/hcontrol.c
+++ b/src/hcontrol.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include "hcontrol.h"
 #include "local.h"
 

--- a/src/hctl_macros.h
+++ b/src/hctl_macros.h
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 struct _snd_hctl {
 	snd_ctl_t *ctl;

--- a/src/hwdep.c
+++ b/src/hwdep.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include "hwdep.h"
 #include "local.h"
 

--- a/src/hwdep_macros.h
+++ b/src/hwdep_macros.h
@@ -11,7 +11,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 struct _snd_hwdep {
 	const char *name;

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include "mixer.h"
 #include "local.h"
 

--- a/src/mixer_macros.h
+++ b/src/mixer_macros.h
@@ -487,7 +487,9 @@ int snd_mixer_selem_set_playback_volume(snd_mixer_elem_t *elem,
 					snd_mixer_selem_channel_id_t channel,
 					long value)
 {
-	return _snd_selem_update_volume(elem->items[SND_SELEM_ITEM_PVOLUME], channel, value);
+	return _snd_selem_update_volume((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
+					channel,
+					value);
 }
 
 __SALSA_EXPORT_FUNC
@@ -495,19 +497,23 @@ int snd_mixer_selem_set_capture_volume(snd_mixer_elem_t *elem,
 				       snd_mixer_selem_channel_id_t channel,
 				       long value)
 {
-	return _snd_selem_update_volume(elem->items[SND_SELEM_ITEM_CVOLUME], channel, value);
+	return _snd_selem_update_volume((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
+					channel,
+					value);
 }
 
 __SALSA_EXPORT_FUNC
 int snd_mixer_selem_set_playback_volume_all(snd_mixer_elem_t *elem, long value)
 {
-	return _snd_selem_update_volume_all(elem->items[SND_SELEM_ITEM_PVOLUME], value);
+	return _snd_selem_update_volume_all((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
+					    value);
 }
 
 __SALSA_EXPORT_FUNC
 int snd_mixer_selem_set_capture_volume_all(snd_mixer_elem_t *elem, long value)
 {
-	return _snd_selem_update_volume_all(elem->items[SND_SELEM_ITEM_CVOLUME], value);
+	return _snd_selem_update_volume_all((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
+					    value);
 }
 
 __SALSA_EXPORT_FUNC
@@ -531,7 +537,7 @@ int snd_mixer_selem_is_enum_capture(snd_mixer_elem_t *elem)
 __SALSA_EXPORT_FUNC
 int snd_mixer_selem_get_enum_items(snd_mixer_elem_t *elem)
 {
-	snd_selem_enum_item_t *eitem = elem->items[SND_SELEM_ITEM_ENUM];
+	snd_selem_enum_item_t *eitem = (snd_selem_enum_item_t *)elem->items[SND_SELEM_ITEM_ENUM];
 	if (!eitem)
 		return -EINVAL;
 	return eitem->items;
@@ -542,7 +548,7 @@ int snd_mixer_selem_get_enum_item(snd_mixer_elem_t *elem,
 				  snd_mixer_selem_channel_id_t channel,
 				  unsigned int *itemp)
 {
-	snd_selem_enum_item_t *eitem = elem->items[SND_SELEM_ITEM_ENUM];
+	snd_selem_enum_item_t *eitem = (snd_selem_enum_item_t *)elem->items[SND_SELEM_ITEM_ENUM];
 	if (!eitem || (unsigned int)channel >= eitem->head.channels)
 		return -EINVAL;
 	*itemp =  eitem->item[channel];
@@ -602,7 +608,7 @@ __SALSA_EXPORT_FUNC
 int snd_mixer_selem_get_playback_dB_range(snd_mixer_elem_t *elem,
 					  long *min, long *max)
 {
-	return _snd_selem_vol_get_dB_range(elem->items[SND_SELEM_ITEM_PVOLUME],
+	return _snd_selem_vol_get_dB_range((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
 					   min, max);
 }
 
@@ -611,7 +617,7 @@ int snd_mixer_selem_get_playback_dB(snd_mixer_elem_t *elem,
 				    snd_mixer_selem_channel_id_t channel,
 				    long *value)
 {
-	return _snd_selem_vol_get_dB(elem->items[SND_SELEM_ITEM_PVOLUME],
+	return _snd_selem_vol_get_dB((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
 				     channel, value);
 }
 
@@ -619,7 +625,7 @@ __SALSA_EXPORT_FUNC
 int snd_mixer_selem_ask_playback_vol_dB(snd_mixer_elem_t *elem, long value,
 					long *dBvalue)
 {
-	return _snd_selem_ask_vol_dB(elem->items[SND_SELEM_ITEM_PVOLUME],
+	return _snd_selem_ask_vol_dB((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
 				     value, dBvalue);
 }
 
@@ -627,7 +633,7 @@ __SALSA_EXPORT_FUNC
 int snd_mixer_selem_ask_playback_dB_vol(snd_mixer_elem_t *elem, long dBvalue,
 					int dir, long *value)
 {
-	return _snd_selem_ask_dB_vol(elem->items[SND_SELEM_ITEM_PVOLUME],
+	return _snd_selem_ask_dB_vol((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
 				     dBvalue, value, dir);
 }
 
@@ -636,7 +642,7 @@ int snd_mixer_selem_set_playback_dB(snd_mixer_elem_t *elem,
 				    snd_mixer_selem_channel_id_t channel,
 				    long value, int dir)
 {
-	return _snd_selem_vol_set_dB(elem->items[SND_SELEM_ITEM_PVOLUME],
+	return _snd_selem_vol_set_dB((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
 				     (int)channel, value, dir);
 }
 
@@ -644,14 +650,15 @@ __SALSA_EXPORT_FUNC
 int snd_mixer_selem_set_playback_dB_all(snd_mixer_elem_t *elem, long value,
 					int dir)
 {
-	return _snd_selem_vol_set_dB_all(elem->items[SND_SELEM_ITEM_PVOLUME], value, dir);
+	return _snd_selem_vol_set_dB_all((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_PVOLUME],
+					 value, dir);
 }
 
 __SALSA_EXPORT_FUNC
 int snd_mixer_selem_get_capture_dB_range(snd_mixer_elem_t *elem,
 					 long *min, long *max)
 {
-	return _snd_selem_vol_get_dB_range(elem->items[SND_SELEM_ITEM_CVOLUME],
+	return _snd_selem_vol_get_dB_range((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
 					   min, max);
 }
 
@@ -660,7 +667,7 @@ int snd_mixer_selem_get_capture_dB(snd_mixer_elem_t *elem,
 				   snd_mixer_selem_channel_id_t channel,
 				   long *value)
 {
-	return _snd_selem_vol_get_dB(elem->items[SND_SELEM_ITEM_CVOLUME],
+	return _snd_selem_vol_get_dB((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
 				     channel, value);
 }
 
@@ -668,7 +675,7 @@ __SALSA_EXPORT_FUNC
 int snd_mixer_selem_ask_capture_vol_dB(snd_mixer_elem_t *elem, long value,
 				       long *dBvalue)
 {
-	return _snd_selem_ask_vol_dB(elem->items[SND_SELEM_ITEM_CVOLUME],
+	return _snd_selem_ask_vol_dB((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
 				     value, dBvalue);
 }
 
@@ -676,7 +683,7 @@ __SALSA_EXPORT_FUNC
 int snd_mixer_selem_ask_capture_dB_vol(snd_mixer_elem_t *elem, long dBvalue,
 				       int dir, long *value)
 {
-	return _snd_selem_ask_dB_vol(elem->items[SND_SELEM_ITEM_CVOLUME],
+	return _snd_selem_ask_dB_vol((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
 				     dBvalue, value, dir);
 }
 
@@ -685,7 +692,7 @@ int snd_mixer_selem_set_capture_dB(snd_mixer_elem_t *elem,
 				   snd_mixer_selem_channel_id_t channel,
 				   long value, int dir)
 {
-	return _snd_selem_vol_set_dB(elem->items[SND_SELEM_ITEM_CVOLUME],
+	return _snd_selem_vol_set_dB((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
 				     channel, value, dir);
 }
 
@@ -693,7 +700,8 @@ __SALSA_EXPORT_FUNC
 int snd_mixer_selem_set_capture_dB_all(snd_mixer_elem_t *elem, long value,
 				       int dir)
 {
-	return _snd_selem_vol_set_dB_all(elem->items[SND_SELEM_ITEM_CVOLUME], value, dir);
+	return _snd_selem_vol_set_dB_all((snd_selem_vol_item_t *)elem->items[SND_SELEM_ITEM_CVOLUME],
+					 value, dir);
 }
 
 #else /* SALSA_HAS_TLV_SUPPORT */

--- a/src/mixer_macros.h
+++ b/src/mixer_macros.h
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 struct _snd_mixer {
 	snd_hctl_t *hctl;

--- a/src/pcm_macros.h
+++ b/src/pcm_macros.h
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 typedef struct {
 	struct sndrv_pcm_channel_info info;

--- a/src/rawmidi.c
+++ b/src/rawmidi.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include "rawmidi.h"
 #include "control.h"
 #include "local.h"

--- a/src/rawmidi_macros.h
+++ b/src/rawmidi_macros.h
@@ -13,7 +13,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 typedef struct _snd_rawmidi_hw {
 	char *name;

--- a/src/timer.c
+++ b/src/timer.c
@@ -26,7 +26,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <signal.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include "timer.h"
 #include "local.h"
 

--- a/src/timer_macros.h
+++ b/src/timer_macros.h
@@ -11,7 +11,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 struct _snd_timer {
 	char *name;


### PR DESCRIPTION
g++ does not allow implicit casting of void \* to another pointer type
(at least not without -fpermissive)
