### PR TITLE
fix invalid cast

### DIFF
--- a/src/conf.h
+++ b/src/conf.h
@@ -69,7 +69,7 @@ __SALSA_EXPORT_FUNC
 int snd_config_update_ref(snd_config_t **top)
 {
 	/* an invalid address, but just mark to be non-NULL */
-	top = (snd_config_t*)1;
+	*top = (snd_config_t*)1;
 	snd_config_update();
 	return 0;
 }


### PR DESCRIPTION
I get this error when compiling

```
error: assignment to 'snd_config_t **' {aka 'struct _snd_config **'} from incompatible pointer type 'snd_config_t *' {aka 'struct _snd_config *'} [-Werror=incompatible-pointer-types]
|         top = (snd_config_t*)1;
|             ^
```