### PR TITLE
pcm: Fill sw_params proto field

### DIFF
--- a/src/asound.h
+++ b/src/asound.h
@@ -403,8 +403,8 @@ typedef struct snd_pcm_sw_params {
 	snd_pcm_uframes_t silence_threshold;
 	snd_pcm_uframes_t silence_size;
 	snd_pcm_uframes_t boundary;
-	unsigned int tstamp_type;
-	int pads;
+	unsigned int proto;			/* protocol version */
+	unsigned int tstamp_type;		/* timestamp type (req. proto >= 2.0.12) */
 	unsigned char reserved[52];
 	unsigned int period_event;
 } snd_pcm_sw_params_t;

--- a/src/pcm_params.c
+++ b/src/pcm_params.c
@@ -346,6 +346,7 @@ static int snd_interval_refine_set(snd_interval_t *i, unsigned int val)
 static int snd_pcm_sw_params_default(snd_pcm_t *pcm,
 				     snd_pcm_sw_params_t *params)
 {
+	params->proto = SNDRV_PCM_VERSION;
 	params->tstamp_mode = SND_PCM_TSTAMP_NONE;
 	params->tstamp_type = pcm->sw_params.tstamp_type;
 	params->period_step = 1;


### PR DESCRIPTION
As per upstream commit 55c53625212702debf55c719ec62f6c81c780927:

Fill the new proto field introduced to sw_params with the current PCM
protocol version.  This makes tstamp_type evaluated properly in the
kernel.